### PR TITLE
wire: use `FileDescriptor` interface for `WriteFile`

### DIFF
--- a/wire/encode.go
+++ b/wire/encode.go
@@ -117,7 +117,7 @@ func (mb *MessageBuilder) WriteArray(v []byte) {
 	}
 }
 
-func (mb *MessageBuilder) WriteFile(v *os.File) {
+func (mb *MessageBuilder) WriteFile(v FileDescriptor) {
 	fd, err := unix.Dup(int(v.Fd()))
 	if err != nil {
 		mb.err = err

--- a/wire/encode.go
+++ b/wire/encode.go
@@ -117,8 +117,12 @@ func (mb *MessageBuilder) WriteArray(v []byte) {
 	}
 }
 
-func (mb *MessageBuilder) WriteFile(v FileDescriptor) {
-	fd, err := unix.Dup(int(v.Fd()))
+func (mb *MessageBuilder) WriteFile(file *os.File) {
+	mb.WriteFD(int(file.Fd()))
+}
+
+func (mb *MessageBuilder) WriteFD(file int) {
+	fd, err := unix.Dup(file)
 	if err != nil {
 		mb.err = err
 		return

--- a/wire/wire.go
+++ b/wire/wire.go
@@ -93,8 +93,3 @@ type State interface {
 type Binder interface {
 	Bind(name uint32, obj NewID)
 }
-
-type FileDescriptor interface {
-	// Fd returns a valid file descriptor
-	Fd() uintptr
-}

--- a/wire/wire.go
+++ b/wire/wire.go
@@ -93,3 +93,8 @@ type State interface {
 type Binder interface {
 	Bind(name uint32, obj NewID)
 }
+
+type FileDescriptor interface {
+	// Fd returns a valid file descriptor
+	Fd() uintptr
+}


### PR DESCRIPTION
hi, now the MessageBuilder.WriteFile method is tied to *os.File and does not allow passing the descriptor from other structures, I propose not to be tied to *os.File and use the FileDescriptor interface for this purpose